### PR TITLE
6: Use WiFi MAC to request 'self' device

### DIFF
--- a/src/app/Kconfig
+++ b/src/app/Kconfig
@@ -13,10 +13,4 @@ menu "Poll"
         help
           Server name expected by the nginx ingress (if any). This could differ
           from GANYMEDE_HOST when deploying the server on a local network.
-
-    config GANYMEDE_DEVICE_ID
-        string "Ganymede Device ID"
-        help
-          MAC-address lookup is not yet supported, so the Device ID must be
-          hard-coded into the code.
 endmenu

--- a/src/app/main.c
+++ b/src/app/main.c
@@ -84,9 +84,11 @@ void app_main(void)
                 if (strcmp(linebuf, "register") == 0) {
                     auth_request_register();
                 }
-
-                if (strcmp(linebuf, "memory") == 0) {
+                else if (strcmp(linebuf, "memory") == 0) {
                     report_memory();
+                }
+                else if (strcmp(linebuf, "poll") == 0) {
+                    poll_request_refresh();
                 }
             } else {
                 linebuf[cursor++] = (char) c;

--- a/src/app/poll.h
+++ b/src/app/poll.h
@@ -2,5 +2,6 @@
 #define APP__POLL_H_
 
 int app_poll_init();
+void poll_request_refresh();
 
 #endif


### PR DESCRIPTION
Uses `esp_read_mac(..., WIFI_STA)` to get the base MAC address of the ESP device and send it to the server in the GetDevice call.

Removes the GANYMEDE_DEVICE_ID config element.

Fixes #6.